### PR TITLE
bumpup deno 1.14.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hayd/alpine-deno:1.7.1
+FROM denoland/deno:1.14.0
 
 WORKDIR /app
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,7 @@
-import { serve } from "https://deno.land/std@0.85.0/http/server.ts";
+import { listenAndServe } from "https://deno.land/std@0.107.0/http/server.ts"
 
-let port = parseInt(Deno.env.get("PORT") ?? "8000")
-const s = serve({ port });
+const port = parseInt(Deno.env.get("PORT") ?? "8000")
 
-console.log(`http://localhost:${port}/`);
+listenAndServe(`:${port}`, () => new Response("Choo Choo! Welcome to your Deno app\n"))
 
-for await (const req of s) {
-  req.respond({ body: "Choo Choo! Welcome to your Deno app\n" });
-}
+console.log(`http://localhost:${port}/`)


### PR DESCRIPTION
## description

- bumpup to deno 1.14.0.
- update use Deno's HTTP server APIs.